### PR TITLE
Declaração de acesso a  rede para o rocketchat

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yml
@@ -425,6 +425,9 @@ services:
 
   rocketchat:
     image: rocketchat/rocket.chat:latest
+    networks:
+      - traefik-public
+      - default
     command: >
       bash -c
         "for i in `seq 1 30`; do


### PR DESCRIPTION
Declaração para o rocketchat usar a acessar a rede default (mesma do mondongo) e a do traefik pública quando o traefik está em outro docker.